### PR TITLE
underscore to dash

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@
 fqdn = node['set_fqdn']
 if fqdn
   # set the domain and hostname from the node name by default
-  hostname, domain = node.name.split('.', 2) if !node.name.nil? && !node.name.empty?
+  hostname, domain = node.name.gsub('_', '-').split('.', 2) if !node.name.nil? && !node.name.empty?
   # if we have the hostname in the fqdn, use that instead
   if fqdn =~ /\*\./
     domain = fqdn.sub('*.', '')


### PR DESCRIPTION
Underscores are not acceptable in a hostname but I think many node names have underscores.  So I made a fix that will convert the underscores to dashes automatically.
