### PR TITLE
updated with amazon linux compatibility

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,7 +63,8 @@ if fqdn
     end
 
   when 'centos', 'redhat', 'amazon', 'scientific'
-    if node['platform_version'].to_f >= 7
+    # amazon linux does not support hostnamectl
+    if node['platform_version'].to_f >= 7 && node['platform'] != 'amazon'
       execute "hostnamectl set-hostname #{hostname}" do
         only_if { node['hostname'] != hostname }
         notifies :reload, 'ohai[reload_hostname]', :immediately


### PR DESCRIPTION
Amazon Linux uses a platform_version in the format of YYYY.M (e.g. 2016.7) but does not currently use systemd so the el7 compatibility merge has broken this cookbook.

This PR will revert to the previous functionality when executed on the Amazon Linux platform
