### PR TITLE
Updating for Chef / ChefSpec Deprecation Warnings

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,4 +2,4 @@
 
 default['hostname_cookbook']['use_node_ip'] = false
 default['hostname_cookbook']['hostsfile_ip'] = '127.0.1.1'
-default['hostname_cookbook']['hostsfile_ip_interface'] = 'lo0' if platform == 'freebsd'
+default['hostname_cookbook']['hostsfile_ip_interface'] = 'lo0' if node['platform'] == 'freebsd'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'nathan@vertile.com'
 license          'MIT'
 description      'Configures hostname and FQDN'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.1'
+version          '0.4.2'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,7 +57,7 @@ if fqdn
         if node['hostname_cookbook']['hostsfile_ip_interface']
     end
 
-    execute "hostname #{fqdn}" do
+    execute "hostnames #{fqdn}" do
       only_if { node['fqdn'] != fqdn }
       notifies :reload, 'ohai[reload_hostname]', :immediately
     end
@@ -93,7 +93,7 @@ if fqdn
         notifies :reload, 'ohai[reload_hostname]', :immediately
         notifies :restart, 'service[network]', :delayed
       end
-      execute "hostname #{hostname}" do
+      execute "hostnames #{hostname}" do
         only_if { node['hostname'] != hostname }
         notifies :reload, 'ohai[reload_hostname]', :immediately
       end
@@ -105,7 +105,7 @@ if fqdn
       notifies :reload, 'ohai[reload_hostname]', :immediately
     end
 
-    execute "hostname #{hostname}" do
+    execute "hostnames #{hostname}" do
       only_if { node['hostname'] != hostname }
       notifies :reload, 'ohai[reload_hostname]', :immediately
     end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
 require 'chefspec'
+require 'chefspec/berkshelf'
 
 describe 'hostnames::default' do
-  let(:chef_run) { ChefSpec::Runner.new }
+  let(:chef_run) { ChefSpec::SoloRunner.new }
 
   it 'sets FQDN' do
-    chef_run.node.set['set_fqdn'] = 'test.example.com'
-    chef_run.converge 'hostnames'
+    chef_run.node.override['set_fqdn'] = 'test.example.com'
+    chef_run.converge described_recipe
 
     expect(chef_run).to render_file('/etc/hostname').with_content("test\n")
     expect(chef_run).to run_execute('hostnames test')
@@ -15,8 +16,8 @@ describe 'hostnames::default' do
 
   it "substitutes star to node's name" do
     chef_run.node.name 'test'
-    chef_run.node.set['set_fqdn'] = '*.example.com'
-    chef_run.converge 'hostnames'
+    chef_run.node.override['set_fqdn'] = '*.example.com'
+    chef_run.converge described_recipe
 
     expect(chef_run).to render_file('/etc/hostname').with_content("test\n")
     expect(chef_run).to run_execute('hostnames test')

--- a/spec/vmware_spec.rb
+++ b/spec/vmware_spec.rb
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 require 'chefspec'
+require 'chefspec/berkshelf'
 
 describe 'hostnames::vmware' do
-  let(:chef_run) { ChefSpec::Runner.new.converge 'hostname::vmware' }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge described_recipe }
 end


### PR DESCRIPTION
I've been updating our company cookbooks to use ChefSpec / Test Kitchen and ran into some weird output that I've tracked down to Chef complaining the use of deprecated stuff in this cookbook. Specifically, I'm getting this:

```[2017-01-13T09:39:03-05:00] INFO: Run List expands to []
platform
[2017-01-13T09:39:03-05:00] WARN: method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"]) at /var/folders/9r/0jqr4hkd0hj6273zzwp38x4r0000gn/T/d20170113-56814-10e4it8/cookbooks/hostnames/attributes/default.rb:5:in `from_file' at /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.16.42/lib/chef/event_dispatch/dispatcher.rb:43:in `call'
```

The 'platform' output is the node attribute being accessed in method format and that is output by Chef (which is REALLY annoying because I can't stop it from happening).

I can't do much about the Chef side, but figured I could help here, so I posted some updates to fix that deprecation warning as well as fixing the unit tests in this cookbook (they didn't run locally for me.)

Hopefully this helps out.